### PR TITLE
large file mode to csvigo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,8 @@ CMAKE_POLICY(VERSION 2.6)
 FIND_PACKAGE(Torch REQUIRED)
 
 SET(luasrc init.lua File.lua)
+SET(src init.c)
 
-ADD_TORCH_PACKAGE(csvigo "" "${luasrc}" "CSV Reader/Writer")
+ADD_TORCH_PACKAGE(csvigo "${src}" "${luasrc}" "CSV Reader/Writer")
+
+TARGET_LINK_LIBRARIES(csvigo luaT TH )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install:
 
 First install Torch7 (www.torch.ch) then simply install this package
-using torch-rocks:
+using luarocks:
 
 ```
 luarocks install csvigo
@@ -29,3 +29,60 @@ function, simply do:
 -- print some help
 > all = query('all')
 > subset = query('union', {somevar=someval, someothervar={val1, val2}})
+
+## Large CSV mode
+
+CSVigo supports efficient loading of very large CSV files into memory.
+The loaded data structure is a read-only table with efficiency hidden under the hood.
+
+Loading:
+
+```lua
+m = csvigo.load({path = "my_large.csv", mode = "large"})
+```
+
+Printing by default only prints first 10 and last 10 rows
+```lua
+print(m)
+```
+
+Individual element access
+```lua
+print(m[32])
+```
+
+Size of table:
+```lua
+print(#m)
+```
+
+For loop over entries:
+
+Type 1:
+```lua
+for i=1, #m do
+    print(m[i]) -- get element
+end
+```
+
+Type 2:
+```lua
+for k,v in ipairs(m) do
+    print(k)
+    print(v)
+end
+```
+
+Type 3:
+```lua
+for k,v in pairs(m) do
+    print(k)
+    print(v)
+end
+```
+
+Read-only table
+```lua
+-- read only table, will error here:
+m[13] = 'a'
+```

--- a/csvigo-scm-1.rockspec
+++ b/csvigo-scm-1.rockspec
@@ -20,9 +20,9 @@ dependencies = {
 }
 
 build = {
-   type = "builtin",
-   modules = {
-      ['csvigo.init'] = 'init.lua',
-      ['csvigo.File'] = 'File.lua'
-   }
+      type = "command",
+      build_command = [[
+cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
+]],
+        install_command = "cd build && $(MAKE) install"
 }

--- a/init.c
+++ b/init.c
@@ -1,0 +1,71 @@
+#include "TH.h"
+#include "luaT.h"
+
+#if LUA_VERSION_NUM == 501
+static void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup)
+{
+  luaL_checkstack(L, nup+1, "too many upvalues");
+  for (; l->name != NULL; l++) {  /* fill the table with given functions */
+    int i;
+    lua_pushstring(L, l->name);
+    for (i = 0; i < nup; i++)  /* copy upvalues to the top */
+      lua_pushvalue(L, -(nup+1));
+    lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
+    lua_settable(L, -(nup + 3));
+  }
+  lua_pop(L, nup);  /* remove upvalues */
+}
+#endif
+
+static int create_lookup(lua_State* L)
+{
+
+  THCharStorage *input = luaT_checkudata(L, 1, "torch.CharStorage");
+  char* data = THCharStorage_data(input);
+  long length = input->size;
+
+  long num_lines = 0;
+  long i;
+#pragma omp parallel for private(i)
+  for (i = 0; i < length; i++) {
+    if (data[i] == '\n') {
+      num_lines++;
+    }
+  }
+
+  if (data[length-1] != '\n') {
+    num_lines++;
+  }
+
+  THLongTensor* lookup = THLongTensor_newWithSize2d(num_lines, 2);
+  long* ldata = THLongTensor_data(lookup);
+
+  long offset = 0;
+  for (i = 0; i < length; i++) {
+    if (data[i] == '\n') {
+      *ldata++ = offset;
+      *ldata++ = i - offset;
+      offset = i+1;
+    }
+  }
+  if (data[length-1] != '\n') {
+    *ldata++ = offset;
+    *ldata++ = length - offset;
+  }
+
+  luaT_pushudata(L, lookup, "torch.LongTensor");
+
+  return 1;
+}
+
+
+static const struct luaL_Reg lib[] = {
+  {"create_lookup", create_lookup},
+  {NULL, NULL},
+};
+
+int luaopen_libcsvigo (lua_State *L) {
+  lua_newtable(L);
+  luaL_setfuncs(L, lib, 0);
+  return 1;
+}

--- a/init.lua
+++ b/init.lua
@@ -52,17 +52,17 @@ function csvigo.load(...)
    local args, path, separator, mode, header, verbose, skip, large = dok.unpack(
       {...},
       'csvigo.load',
-      'Load a CSV file, according to the specifided mode:\n'
+      'Load a CSV file, according to the specified mode:\n'
       .. ' - raw   : no clean up, return a raw list of lists, a 1-to-1 mapping to the CSV file\n'
       .. ' - tidy  : return a clean table, where each entry is a variable that points to its values\n'
-      .. ' - query : return the tidy table, as well as query operators',
+      .. ' - query : return the tidy table, as well as query operators\n'
+      .. ' - large : returns a table that decodes rows on the fly, on indexing ',
       {arg='path',      type='string',  help='path to file', req=true},
       {arg='separator', type='string',  help='separator (one character)', default=','},
       {arg='mode',      type='string',  help='load mode: raw | tidy | query', default='tidy'},
       {arg='header',    type='boolean', help='file has a header (variable names)', default=true},
       {arg='verbose',   type='boolean', help='verbose load', default=true},
-      {arg='skip',      type='number',  help='skip this many lines at start of file', default=0},
-      {arg='large',     type='boolean', help='Set to true when loading large files', default=false}
+      {arg='skip',      type='number',  help='skip this many lines at start of file', default=0}
    )
 
    -- check path
@@ -73,12 +73,12 @@ function csvigo.load(...)
 
    -- load CSV
    vprint('parsing file: ' .. path)
-   local f = csvigo.File(path,'r',separator)
-   local loaded = f:readall(large)
+   local f = csvigo.File(path, 'r', separator)
+   local loaded = f:readall(mode)
    f:close()
 
    -- do work depending on mode
-   if mode == 'raw' then
+   if mode == 'raw' or mode == 'large' then
       -- simple, dont do anything
       vprint('parsing done')
       return loaded


### PR DESCRIPTION
CSVigo supports efficient loading of very large CSV files into memory.
The loaded data structure is a read-only table with efficiency hidden under the hood.

Loading:

```lua
m = csvigo.load({path = "my_large.csv", mode = "large"})
```

Printing by default only prints first 10 and last 10 rows
```lua
print(m)
```

Individual element access
```lua
print(m[32])
```

Size of table:
```lua
print(#m)
```

For loop over entries:

Type 1:
```lua
for i=1, #m do
    print(m[i]) -- get element
end
```

Type 2:
```lua
for k,v in ipairs(m) do
    print(k)
    print(v)
end
```

Type 3:
```lua
for k,v in pairs(m) do
    print(k)
    print(v)
end
```

Read-only table
```lua
-- read only table, will error here:
m[13] = 'a'
```